### PR TITLE
Create ext.properties

### DIFF
--- a/panthera/ext.properties
+++ b/panthera/ext.properties
@@ -1,0 +1,6 @@
+[panthera]
+group = Runtime
+help = Settings for Panthera extension
+
+hotreload_animations.type = bool
+hotreload_animations.private = 1


### PR DESCRIPTION
[Soon](https://github.com/defold/defold/pull/11125), it will be possible to show extension settings in the `game.project` form. This PR adds `ext.properties` to show used settings:
<img width="646" height="784" alt="Screenshot 2025-08-22 at 15 30 07" src="https://github.com/user-attachments/assets/a309dd69-e01b-4bcc-a371-dd165717ec85" />
